### PR TITLE
bugfix in gstats_print

### DIFF
--- a/src/fiat/gstats/gstats_print.F90
+++ b/src/fiat/gstats/gstats_print.F90
@@ -453,11 +453,6 @@ ELSEIF(LSTATS) THEN
            IF(NUMRECV(JNUM) /= 0) THEN
              AVGRECVLEN=RECVBYTES(JNUM)*1.E-3_JPRD/NUMRECV(JNUM)
            ELSE
-             AVGSENDLEN=0.0_JPRD
-           ENDIF
-           IF(NUMRECV(JNUM) /= 0) THEN
-             AVGRECVLEN=RECVBYTES(JNUM)*1.E-3_JPRD/NUMRECV(JNUM)
-           ELSE
              AVGRECVLEN=0.0_JPRD
            ENDIF
            WRITE(KULOUT,'(I6,1X,A40,f6.1,2(I8,3F8.1))') &


### PR DESCRIPTION
Fixed a copy and paste mistake in gstats_print.F90. Before, AVGSENDLEN was always set to 0 if there were no RECV operations within the gstats section.