### PR TITLE
Fix downstream detection of optional dependencies.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,6 +120,8 @@ if( target_build_type STREQUAL STATIC_LIBRARY OR TARGET fiat-static )
   set( fiat_REQUIRES_PRIVATE_DEPENDENCIES TRUE )
 endif()
 
+set(FIAT_CMAKEMACROS_DIR "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+
 ecbuild_install_project( NAME fiat )
 
 ecbuild_print_summary()

--- a/cmake/fiat-import.cmake.in
+++ b/cmake/fiat-import.cmake.in
@@ -15,12 +15,21 @@ set( fiat_VERSION_STR @fiat_VERSION_STR@ )
 set( fiat_HAVE_MPI    @fiat_HAVE_MPI@ )
 set( fiat_HAVE_OMP    @fiat_HAVE_OMP@ )
 set( fiat_HAVE_FCKIT  @fiat_HAVE_FCKIT@ )
+set( fiat_HAVE_DR_HOOK_NVTX   @fiat_HAVE_DR_HOOK_NVTX@ )
+set( fiat_HAVE_DR_HOOK_ROCTX  @fiat_HAVE_DR_HOOK_ROCTX@ )
+set( fiat_HAVE_DR_HOOK_PAPI   @fiat_HAVE_DR_HOOK_PAPI@ )
 set( fiat_HAVE_SINGLE_PRECISION   @fiat_HAVE_SINGLE_PRECISION@ )
 set( fiat_HAVE_DOUBLE_PRECISION   @fiat_HAVE_DOUBLE_PRECISION@ )
 set( fiat_HAVE_MPL_F08 @fiat_HAVE_MPL_F08@ )
 set( fiat_REQUIRES_PRIVATE_DEPENDENCIES @fiat_REQUIRES_PRIVATE_DEPENDENCIES@ )
 
 set( fiat_SOURCE_FILENAMES      @fiat_SOURCE_FILENAMES@ )
+
+
+# This variable picks up the source dir location for builds
+set(FIAT_CMAKEMACROS_DIR @FIAT_CMAKEMACROS_DIR@)
+list(APPEND CMAKE_MODULE_PATH ${FIAT_CMAKEMACROS_DIR})
+
 
 if( fiat_HAVE_OMP AND NOT TARGET OpenMP::OpenMP_Fortran )
     if( NOT CMAKE_Fortran_COMPILER_LOADED )
@@ -37,6 +46,18 @@ if( fiat_HAVE_MPI AND NOT TARGET MPI::MPI_Fortran )
     if (CMAKE_Fortran_COMPILER_ID MATCHES "NVHPC|IntelLLVM" OR fiat_REQUIRES_PRIVATE_DEPENDENCIES)
         find_dependency( MPI COMPONENTS Fortran )
     endif()
+endif()
+
+if( fiat_HAVE_DR_HOOK_NVTX ) 
+    find_dependency( NVTX )
+endif()
+
+if( fiat_HAVE_DR_HOOK_ROCTX ) 
+    find_dependency( ROCTX )
+endif()
+
+if( fiat_HAVE_DR_HOOK_PAPI ) 
+    find_dependency( PAPI )
 endif()
 
 if( fiat_HAVE_FCKIT AND NOT TARGET fckit )

--- a/src/fiat/CMakeLists.txt
+++ b/src/fiat/CMakeLists.txt
@@ -145,13 +145,8 @@ foreach( LIB_TYPE ${LIB_TYPES} )
         target_compile_definitions(${fiatlib} PRIVATE DR_HOOK_HAVE_NVTX=1 HAVE_NVTX3=${HAVE_NVTX3} )
 
         # Link with NVTX
-	#if (CMAKE_Fortran_COMPILER_ID MATCHES "NVHPC|IntelLLVM")
-	#    target_link_libraries     (${fiatlib} PUBLIC ${NVTX_LIBRARIES})
-	#    target_include_directories(${fiatlib} PUBLIC ${NVTX_INCLUDE_DIRS})
-	#else()
-            target_link_libraries     (${fiatlib} PRIVATE ${NVTX_LIBRARIES})
-            target_include_directories(${fiatlib} PRIVATE ${NVTX_INCLUDE_DIRS})
-	#endif()
+        target_link_libraries     (${fiatlib} PRIVATE ${NVTX_LIBRARIES})
+        target_include_directories(${fiatlib} PRIVATE ${NVTX_INCLUDE_DIRS})
     endif()
     set(LINK_FIAT_MPI_LIBRARIES PUBLIC_LIBS ${FIAT_MPI_LIBRARIES})
 

--- a/src/fiat/CMakeLists.txt
+++ b/src/fiat/CMakeLists.txt
@@ -145,9 +145,15 @@ foreach( LIB_TYPE ${LIB_TYPES} )
         target_compile_definitions(${fiatlib} PRIVATE DR_HOOK_HAVE_NVTX=1 HAVE_NVTX3=${HAVE_NVTX3} )
 
         # Link with NVTX
-        target_link_libraries     (${fiatlib} PRIVATE ${NVTX_LIBRARIES})
-        target_include_directories(${fiatlib} PRIVATE ${NVTX_INCLUDE_DIRS})
+	#if (CMAKE_Fortran_COMPILER_ID MATCHES "NVHPC|IntelLLVM")
+	#    target_link_libraries     (${fiatlib} PUBLIC ${NVTX_LIBRARIES})
+	#    target_include_directories(${fiatlib} PUBLIC ${NVTX_INCLUDE_DIRS})
+	#else()
+            target_link_libraries     (${fiatlib} PRIVATE ${NVTX_LIBRARIES})
+            target_include_directories(${fiatlib} PRIVATE ${NVTX_INCLUDE_DIRS})
+	#endif()
     endif()
+    set(LINK_FIAT_MPI_LIBRARIES PUBLIC_LIBS ${FIAT_MPI_LIBRARIES})
 
     if (HAVE_DR_HOOK_ROCTX)
         # Files from within DrHook
@@ -157,8 +163,8 @@ foreach( LIB_TYPE ${LIB_TYPES} )
         target_compile_definitions(${fiatlib} PRIVATE DR_HOOK_HAVE_ROCTX=1 HAVE_ROCPROFILER_SDK_ROCTX=${HAVE_ROCPROFILER_SDK_ROCTX})
 
         # Link with ROCTX
-        target_link_libraries     (${fiatlib} PRIVATE ${ROCTX_LIBRARIES})
-        target_include_directories(${fiatlib} PRIVATE ${ROCTX_INCLUDE_DIRS})
+	target_link_libraries     (${fiatlib} PRIVATE ${ROCTX_LIBRARIES})
+	target_include_directories(${fiatlib} PRIVATE ${ROCTX_INCLUDE_DIRS})
     endif()
 
     if (HAVE_DR_HOOK_PAPI)


### PR DESCRIPTION
Allow downstream FIAT consumers to find DR_HOOK optional dependencies with FIAT's FindXXX macros.
Some issues remain with NVHPC compiler